### PR TITLE
Return empty dictionary

### DIFF
--- a/ios/react-native-media-kit/RCTMediaPlayerManager.m
+++ b/ios/react-native-media-kit/RCTMediaPlayerManager.m
@@ -27,7 +27,7 @@ RCT_EXPORT_VIEW_PROPERTY(onPlayerBufferChange, RCTBubblingEventBlock)
 
 
 - (NSDictionary<NSString *, id> *)constantsToExport {
-  return [super constantsToExport];
+    return @{};
 }
 
 RCT_EXPORT_METHOD(pause:(nonnull NSNumber *)reactTag) {


### PR DESCRIPTION
For whatever reason, RN no longer likes calling up into super by default. A survey of other modules with this method show they return a simple structure, including when there are no constants to export.